### PR TITLE
Fixes decoding error for when optionset is null

### DIFF
--- a/traveler-swift-core/TravelerKit/Models/Availability.swift
+++ b/traveler-swift-core/TravelerKit/Models/Availability.swift
@@ -32,11 +32,7 @@ public struct Availability: Decodable {
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.date, in: container, debugDescription: "Incorrect format")
         }
 
-        if container.contains(.optionSet) {
-            do { self.optionSet = try container.decode(BookingOptionSet.self, forKey: .optionSet) } catch { self.optionSet = nil }
-        } else {
-            throw DecodingError.dataCorruptedError(forKey: CodingKeys.date, in: container, debugDescription: "OptionSet does not exist")
-        }
+        self.optionSet = try container.decodeIfPresent(BookingOptionSet.self, forKey: .optionSet)
     }
 }
 


### PR DESCRIPTION
**Description**
Currently, the app throws an "unexpected error" dialog when the optionSet is null and the user tries to select a date. 

When optionSet is null, Android sends "option-id=". This fix does not send option-id at all when optionSet is null. I confirmed with Alex that it does not matter whether or not we send "option-id="

**Issues that should be CLOSED by merge of this PR:**
* Fixes #181 

**Related issues that should be LINKED to this PR:**
* Connects #