### PR TITLE
Adds timezone to ensure that date is displayed correctly

### DIFF
--- a/traveler-ios-ui/TravelerKitUI/ViewControllers/OrderResultViewController.swift
+++ b/traveler-ios-ui/TravelerKitUI/ViewControllers/OrderResultViewController.swift
@@ -45,7 +45,7 @@ open class OrderResultViewController: UITableViewController {
         case .some(let order):
             let cell = tableView.dequeueReusableCell(withIdentifier: orderCellIdentifier, for: indexPath) as! OrderCell
             cell.numberLabel.text = order.referenceNumber
-            cell.dateLabel.text = DateFormatter.dateOnlyFormatter.string(from: order.createdDate)
+            cell.dateLabel.text = ISO8601DateFormatter.dateOnlyFormatter.string(from: order.createdDate)
             cell.productsLabel.text = order.products.map({ $0.title }).joined(separator: "\n")
             cell.priceLabel.text = order.total.localizedDescription
             cell.statusLabel.text = order.status.rawValue

--- a/traveler-swift-core/TravelerKit/Extensions/DateFormatter+PassengerKit.swift
+++ b/traveler-swift-core/TravelerKit/Extensions/DateFormatter+PassengerKit.swift
@@ -44,6 +44,7 @@ extension DateFormatter {
     public static var dateOnlyFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
         return formatter
     }()
 }

--- a/traveler-swift-core/TravelerKit/Extensions/DateFormatter+PassengerKit.swift
+++ b/traveler-swift-core/TravelerKit/Extensions/DateFormatter+PassengerKit.swift
@@ -44,7 +44,6 @@ extension DateFormatter {
     public static var dateOnlyFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(abbreviation: "UTC")
         return formatter
     }()
 }


### PR DESCRIPTION
**Description**
Dates were displaying incorrectly when parsing from Date to String (string reflected day before). Added time zone to date formatter to fix this issue. 

**Issues that should be CLOSED by merge of this PR:**
* Fixes #

**Related issues that should be LINKED to this PR:**
* Connects #