### PR TITLE
Adds buffer variable to calculate safe area intersection correctly.

### DIFF
--- a/traveler-ios-ui/TravelerKitUI/ViewControllers/BookingQuestionsViewController.swift
+++ b/traveler-ios-ui/TravelerKitUI/ViewControllers/BookingQuestionsViewController.swift
@@ -22,6 +22,7 @@ class BookingQuestionsViewController: UIViewController {
     weak var delegate: BookingQuestionsViewControllerDelegate?
 
     private var error: Error?
+    private var originalSafeArea: CGRect?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,14 +36,22 @@ class BookingQuestionsViewController: UIViewController {
 
     @objc
     func keyboardWillChangeFrame(_ note: Notification) {
+        var bottomInset:CGFloat = 0.0
+
         guard let keyboardFrame = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
             return
         }
 
         let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
-        let bottomInset = view.safeAreaLayoutGuide.layoutFrame.intersection(keyboardFrameInView).height
+
+        if let safeArea = originalSafeArea {
+            bottomInset = safeArea.intersection(keyboardFrameInView).height
+        } else {
+            bottomInset = view.safeAreaLayoutGuide.layoutFrame.intersection(keyboardFrameInView).height
+            originalSafeArea = view.safeAreaLayoutGuide.layoutFrame
+        }
+
         additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
-        view.layoutIfNeeded()
     }
 }
 

--- a/traveler-ios-ui/TravelerKitUI/ViewControllers/BookingQuestionsViewController.swift
+++ b/traveler-ios-ui/TravelerKitUI/ViewControllers/BookingQuestionsViewController.swift
@@ -22,7 +22,6 @@ class BookingQuestionsViewController: UIViewController {
     weak var delegate: BookingQuestionsViewControllerDelegate?
 
     private var error: Error?
-    private var originalSafeArea: CGRect?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,22 +35,15 @@ class BookingQuestionsViewController: UIViewController {
 
     @objc
     func keyboardWillChangeFrame(_ note: Notification) {
-        var bottomInset:CGFloat = 0.0
-
         guard let keyboardFrame = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
             return
         }
 
+        let viewControllerInView = view.convert(self.view.frame, from: nil)
         let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
-
-        if let safeArea = originalSafeArea {
-            bottomInset = safeArea.intersection(keyboardFrameInView).height
-        } else {
-            bottomInset = view.safeAreaLayoutGuide.layoutFrame.intersection(keyboardFrameInView).height
-            originalSafeArea = view.safeAreaLayoutGuide.layoutFrame
-        }
-
-        additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        let bottomInset = viewControllerInView.intersection(keyboardFrameInView).height
+        
+        self.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
     }
 }
 


### PR DESCRIPTION
**Description**

Bug Description: 

In Booking Questions VC, the booking form would have inconsistent behaviour when it came to scrolling whenever the keyboard or picker would appear. 

The issue relied on the calculation of the intersection between the safe area and the keyboard. Every time the keyboard would change frames a notification would fire and would calculate the intersection between the keyboard and the safe area AT THAT MOMENT.

That means that if the keyboard was already there (e.g. user selected title field and a picker was showing) and the user would tap a different field (e.g. name, and input would switch from picker to keyboard) the intersection would be recalculated based on a reduced safe area (the one that contained the picker), making scrolling inconsistent. 

This code adds a buffer variable that keeps track of the original safe area and calculates intersection on the original safe area. 

**Issues that should be CLOSED by merge of this PR:**
* Fixes #

**Related issues that should be LINKED to this PR:**
* Connects #