### PR TITLE
Adds cancellation reason model + Adds `cancellationReasons` object wh…

### DIFF
--- a/traveler-ios-ui/TravelerKitUI/ModelExtensions/CancellationError+LocalizedError.swift
+++ b/traveler-ios-ui/TravelerKitUI/ModelExtensions/CancellationError+LocalizedError.swift
@@ -16,6 +16,8 @@ extension CancellationError: LocalizedError {
             return NSLocalizedString("Quote has expired", comment: "CancellationError")
         case .notCancellable:
             return NSLocalizedString("Order not cancellable", comment: "CancellationError")
+        case .explanationRequired:
+            return NSLocalizedString("A cancellation explanation is required", comment: "CancellationError")
         }
     }
 }

--- a/traveler-swift-core/TravelerKit.xcodeproj/project.pbxproj
+++ b/traveler-swift-core/TravelerKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A315F465234692FC00DF8545 /* CancellationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A315F464234692FC00DF8545 /* CancellationRequest.swift */; };
+		A3E3FC49234501AF00CB616B /* CancellationReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E3FC48234501AF00CB616B /* CancellationReason.swift */; };
 		A91E0CD4215E6A2A0017D207 /* SessionBeginOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91E0CD3215E6A2A0017D207 /* SessionBeginOperationTests.swift */; };
 		A91E0CD621625E350017D207 /* DateFormatter+PassengerKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91E0CD521625E350017D207 /* DateFormatter+PassengerKit.swift */; };
 		A91F3BB121B827870016894A /* Array+ContainsAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F3BB021B827870016894A /* Array+ContainsAnyOf.swift */; };
@@ -150,6 +152,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A315F464234692FC00DF8545 /* CancellationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellationRequest.swift; sourceTree = "<group>"; };
+		A3E3FC48234501AF00CB616B /* CancellationReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellationReason.swift; sourceTree = "<group>"; };
 		A91E0CD3215E6A2A0017D207 /* SessionBeginOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionBeginOperationTests.swift; sourceTree = "<group>"; };
 		A91E0CD521625E350017D207 /* DateFormatter+PassengerKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+PassengerKit.swift"; sourceTree = "<group>"; };
 		A91F3BB021B827870016894A /* Array+ContainsAnyOf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ContainsAnyOf.swift"; sourceTree = "<group>"; };
@@ -473,6 +477,8 @@
 				CAAF4A4B234E45AD00919317 /* ParkingItemCategory.swift */,
 				A97F8BCF2358EA9F001A779C /* PaymentAuthenticator.swift */,
 				A97F8BD02358EAA0001A779C /* PaymentError.swift */,
+				A3E3FC48234501AF00CB616B /* CancellationReason.swift */,
+				A315F464234692FC00DF8545 /* CancellationRequest.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -673,6 +679,7 @@
 				CA1B1505234F6E91009661EC /* BookingItemQuery.swift in Sources */,
 				A9825BC02208DD31008AA0C1 /* CustomerContact.swift in Sources */,
 				CA1754D02343B4D800F08F73 /* ProductType.swift in Sources */,
+				A315F465234692FC00DF8545 /* CancellationRequest.swift in Sources */,
 				A9EED5F0215A7D3B003AAA5F /* AuthPath.swift in Sources */,
 				A974A68F2280C42900319683 /* OrderQuery.swift in Sources */,
 				A91F3BB721B87C500016894A /* PassFetchDelegate.swift in Sources */,
@@ -695,6 +702,7 @@
 				CAEB7A7A234D4C7E00C31BD6 /* ParkingItem.swift in Sources */,
 				CA1B150A234F6E91009661EC /* CategoryFacet.swift in Sources */,
 				A9BF40E6218231580090ED1C /* CatalogGroup.swift in Sources */,
+				A3E3FC49234501AF00CB616B /* CancellationReason.swift in Sources */,
 				A9E2AD80219344670063BF79 /* CatalogItemDetails.swift in Sources */,
 				A974A6932280CA9C00319683 /* OrderFetchDelegate.swift in Sources */,
 				CA1B1500234F6E91009661EC /* BookingItemSearchParameters.swift in Sources */,

--- a/traveler-swift-core/TravelerKit/AuthPath.swift
+++ b/traveler-swift-core/TravelerKit/AuthPath.swift
@@ -20,7 +20,7 @@ enum AuthPath {
     case processOrder(Order, Payment)
     case orders(OrderQuery, travelerId: String)
     case cancellationQuote(Order)
-    case cancelOrder(CancellationQuote)
+    case cancelOrder(CancellationRequest)
     case emailOrderConfirmation(Order)
     case wishlistAdd(Product, travelerId: String)
     case wishlistRemove(Product, travelerId: String)
@@ -129,8 +129,13 @@ enum AuthPath {
             }
         case .cancellationQuote(let order):
             urlComponents.path = "/v1/order/\(order.id)/cancellation"
-        case .cancelOrder(let quote):
-            urlComponents.path = "/v1/order/\(quote.order.id)/cancellation/\(quote.id)"
+        case .cancelOrder(let request):
+            urlComponents.path = "/v1/order/\(request.quote.order.id)/cancellation/\(request.quote.id)"
+            urlRequest.jsonBody = [
+                "cancellationReason": request.reason.id,
+                "cancellationReasonText": request.explanation ?? ""
+            ]
+
             urlRequest.method = .patch
         case .emailOrderConfirmation(let order):
             urlComponents.path = "/v1/order/\(order.id)/ticket"

--- a/traveler-swift-core/TravelerKit/Models/CancellationError.swift
+++ b/traveler-swift-core/TravelerKit/Models/CancellationError.swift
@@ -11,4 +11,5 @@ import Foundation
 public enum CancellationError: Error {
     case expiredQuote
     case notCancellable
+    case explanationRequired
 }

--- a/traveler-swift-core/TravelerKit/Models/CancellationQuote.swift
+++ b/traveler-swift-core/TravelerKit/Models/CancellationQuote.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-/// This represents the amount that will be refunded should the corresponding `Order` be cancelled
+/// This represents the details about the cancellation such as refund and expiration date and the corresponding `Order`
 public struct CancellationQuote {
+    /// Identifer
     let id: String
-
     /// Total amount that will be refunded
     public let totalRefund: Price
     /// Charge for cancellation
@@ -22,6 +22,8 @@ public struct CancellationQuote {
     public let products: [ProductCancellationQuote]
     /// The `Order` that was cancelled
     public let order: Order
+    /// The array of cancellation reasons provided for user to choose
+    public let cancellationReasons: [CancellationReason]
 
     init(cancellationQuoteResponse: CancellationQuoteResponse, order: Order) {
         self.id = cancellationQuoteResponse.id
@@ -29,6 +31,7 @@ public struct CancellationQuote {
         self.cancellationCharge = cancellationQuoteResponse.cancellationCharge
         self.expirationDate = cancellationQuoteResponse.expirationDate
         self.products = cancellationQuoteResponse.products
+        self.cancellationReasons = cancellationQuoteResponse.cancellationReasons
         self.order = order
     }
 }
@@ -39,6 +42,7 @@ struct CancellationQuoteResponse: Decodable {
     let cancellationCharge: Price
     let expirationDate: Date
     let products: [ProductCancellationQuote]
+    let cancellationReasons: [CancellationReason]
 
     enum CodingKeys: String, CodingKey {
         case id = "id"
@@ -46,9 +50,10 @@ struct CancellationQuoteResponse: Decodable {
         case cancellationCharge = "cancellationCharge"
         case expirationDate = "quoteExpiresOn"
         case products = "products"
+        case cancellationReasons = "cancellationReasons"
     }
 
-    public init (from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(String.self, forKey: .id)
@@ -64,6 +69,7 @@ struct CancellationQuoteResponse: Decodable {
         }
 
         self.products = try container.decode([ProductCancellationQuote].self, forKey: .products)
+        self.cancellationReasons = try container.decode([CancellationReason].self, forKey: .cancellationReasons)
     }
 }
 

--- a/traveler-swift-core/TravelerKit/Models/CancellationReason.swift
+++ b/traveler-swift-core/TravelerKit/Models/CancellationReason.swift
@@ -1,0 +1,33 @@
+//
+//  CancellationReason.swift
+//  TravelerKit
+//
+//  Created by Ben Ruan on 2019-10-02.
+//  Copyright © 2019 Ata Namvari. All rights reserved.
+//
+
+import Foundation
+
+/// This represents the reason why user wants to cancel the corresponding `Order`
+public struct CancellationReason: Decodable {
+    /// Identifier of the cancellation reason
+    let id: String
+    /// Text representation of the cancellation reason
+    public let description: String
+    /// Boolean value indicating if text explanation needs to be provided by user
+    public let explanationRequired: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id = "id"
+        case description = "value"
+        case explanationRequired = "explanationRequired"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decode(String.self, forKey: .id)
+        self.description = try container.decode(String.self, forKey: .description)
+        self.explanationRequired = try container.decode(Bool.self, forKey: .explanationRequired)
+    }
+}

--- a/traveler-swift-core/TravelerKit/Models/CancellationRequest.swift
+++ b/traveler-swift-core/TravelerKit/Models/CancellationRequest.swift
@@ -1,0 +1,48 @@
+//
+//  CancellationRequest.swift
+//  TravelerKit
+//
+//  Created by Ben Ruan on 2019-10-03.
+//  Copyright © 2019 Ata Namvari. All rights reserved.
+//
+
+import Foundation
+/**
+ A model representing request to cancel an order
+*/
+public struct CancellationRequest {
+    /// This represents the details about the cancellation such as refund and expiration date and the corresponding `Order`
+    public let quote: CancellationQuote
+    /// The reason why the users wants to cancel the order
+    public let reason: CancellationReason
+    /// The textual explanation about why the user wants to cancel the order
+    public let explanation: String?
+
+    /**
+    Initializes a `CancellationRequest`
+
+    - Parameters:
+     - quote: An `CancellationQuote`
+     - reason: An `CancellationReason`
+     - explanation: An optional `String` explanation for the cancellation reason
+
+    - Returns: `CancellationRequest`
+    */
+    public init(quote: CancellationQuote, reason: CancellationReason, explanation: String?) {
+        self.quote = quote
+        self.reason = reason
+        self.explanation = explanation
+    }
+
+    func validate() -> CancellationError? {
+        guard quote.expirationDate > Date() else {
+            return CancellationError.expiredQuote
+        }
+
+        guard explanation != nil || reason.explanationRequired == false else {
+            return CancellationError.explanationRequired
+        }
+
+        return nil
+    }
+}


### PR DESCRIPTION
…ich holds a list of pre-defined cancellation reasons to `CancellationQuote` + Adds `selectedCancellationReason` and `cancellationExplanation` to `CancellationQuote` +  Adds `noReasonSelected` and `noExplanationProvided` to `CancellationError` + Fixes the typo 'competion' for order cancellation in `Traveler.swift` + Adds guard statements to `cancelOrder` in `Traveler.swift` to check if any cancellation reason is selected and explanation is provided when required.

**Description**


**Issues that should be CLOSED by merge of this PR:**
* Fixes #

**Related issues that should be LINKED to this PR:**
* Connects #