### PR TITLE
Always use iso8601 calendar in core SDK

### DIFF
--- a/traveler-ios-ui/TravelerKitUI/Extensions/Date+Day.swift
+++ b/traveler-ios-ui/TravelerKitUI/Extensions/Date+Day.swift
@@ -11,14 +11,14 @@ import Foundation
 extension Date {
     public func minTimeOfDay() -> Date {
         // Time: 00:00:00
-        let components = Calendar.current.dateComponents([.year, .month, .day], from: self)
+        let components = Calendar.current.dateComponents([.era, .year, .month, .day], from: self)
         let date = Calendar.current.date(from: components)
         return date!
     }
     
     public func maxTimeOfDay() -> Date {
         // Time: 23:59:59
-        var components = Calendar.current.dateComponents([.year, .month, .day], from: self)
+        var components = Calendar.current.dateComponents([.era, .year, .month, .day], from: self)
         components.hour = 23
         components.minute = 59
         components.second = 59

--- a/traveler-swift-core/TravelerKit/Extensions/DateFormatter+PassengerKit.swift
+++ b/traveler-swift-core/TravelerKit/Extensions/DateFormatter+PassengerKit.swift
@@ -12,24 +12,28 @@ extension DateFormatter {
 
     public static var withFullDate: DateFormatter = {
         let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .iso8601)
         dateFormatter.dateFormat = "yyyymmdd"
         return dateFormatter
     }()
 
     public static var yearMonthDay: DateFormatter = {
         let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .iso8601)
         dateFormatter.dateFormat = "yyyy/MM/dd"
         return dateFormatter
     }()
 
     public static var withoutTimezone: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         return formatter
     }()
 
     public static var timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.locale = Locale.current
         formatter.dateStyle = .none
         formatter.timeStyle = .short
@@ -38,24 +42,28 @@ extension DateFormatter {
 
     public static var longFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.dateFormat = "EEEE, MMMM d, yyyy"
         return formatter
     }()
 
     public static var monthAsTextFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.dateFormat = "MMMM d, yyyy"
         return formatter
     }()
 
     public static var dateOnlyFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }()
 
     public static var shortDisplayFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
         formatter.dateStyle = .short
         formatter.timeStyle = .short
         return formatter
@@ -63,6 +71,7 @@ extension DateFormatter {
 
     public func fullFormatter(with timeZone: TimeZone) -> DateFormatter {
         let dateFormatter = self.copy() as! DateFormatter
+        dateFormatter.calendar = Calendar(identifier: .iso8601)
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         dateFormatter.timeZone = timeZone
         return dateFormatter


### PR DESCRIPTION
**Description**
Backend only supports iso8601 calendar date formats.

**Issues that should be CLOSED by merge of this PR:**
* Fixes #

**Related issues that should be LINKED to this PR:**
* Connects #