### PR TITLE
Fix wrong attribute name for dynamic categories in v1/booking API call

### DIFF
--- a/traveler-swift-core/TravelerKit/AuthPath.swift
+++ b/traveler-swift-core/TravelerKit/AuthPath.swift
@@ -236,7 +236,7 @@ enum AuthPath {
                 URLQueryItem(name: "city", value: searchQuery.city)]
 
             searchQuery.categories.forEach({ (category) in
-                urlComponents.queryItems?.append(URLQueryItem(name: "categories", value: category.id))
+                urlComponents.queryItems?.append(URLQueryItem(name: "sub_categories", value: category.id))
             })
 
             if let priceRange = searchQuery.priceRange {


### PR DESCRIPTION
**Description**
While working on WLA-524 ticket, I have noticed that SDK is sending a wrong parameter name when querying for bookable items (v1/booking).
Instead of **categories** parameter, we should be using the **sub_categories** parameter, otherwise, we are getting the wrong results.

**Issues that should be CLOSED by merge of this PR:**
* Fixes # --> there is yet no ticket for this PR.

**Related issues that should be LINKED to this PR:**
* Connects #